### PR TITLE
adding ogg extension to be able to download ogg as well as mp3 files

### DIFF
--- a/inc/jquery.mb.miniPlayer.js
+++ b/inc/jquery.mb.miniPlayer.js
@@ -231,7 +231,7 @@
 				$master.after($controlsBox);
 				$controlsBox.html($layout);
 
-				var fileUrl = encodeURI(player.opt.mp3 || player.opt.m4a);
+				var fileUrl = encodeURI(player.opt.mp3 || player.opt.m4a || player.opt.ogg);
 				var fileExtension = fileUrl.substr((Math.max(0, fileUrl.lastIndexOf(".")) || Infinity) + 1);
 
 				//if there's a querystring remove it


### PR DESCRIPTION
At the moment it's not possible to propose ogg files to download, only mp3 is working (while playing ogg files in the player is working well). With an ogg file it's replacing the url with "null". By adding the ogg extension, it will allow webmasters to share ogg files as well.

